### PR TITLE
Support for partial headers

### DIFF
--- a/webug/assets/javascripts/webug.js
+++ b/webug/assets/javascripts/webug.js
@@ -35,7 +35,7 @@ function processWfHeaders(headers)
 		}
 	}
 	if (currentMessage.length > 0 ) {
-		throw new Exception("Unfinished Wildfire header: " + currentMessage);
+		throw new Error("Unfinished Wildfire header: " + currentMessage);
 	}
 	return messages;
 }


### PR DESCRIPTION
Partial wildfire headers are described at http://www.firephp.org/Wiki/Reference/Protocol
as having the following structure:

```
X-Wf-1-1-1-1    17245|[{"Type":"LOG"},["Element 0","Element 1", ... |\
X-Wf-1-1-1-2    | ... ,"Element 399", ... |\
X-Wf-1-1-1-3    | ... ,"Element 799"]]|
```
