### PR TITLE
Prevent empty log lines

### DIFF
--- a/webug/assets/javascripts/logging.js
+++ b/webug/assets/javascripts/logging.js
@@ -3,12 +3,9 @@ chrome.runtime.onMessage.addListener(function(message, sender)
 	if (message.type === "webug.log")
 	{
 		var args = [];
-		if (
-			["group", "groupEnd"].indexOf(message.log_type) === -1 && 
-			message.meta.File.length > 0
-		)
+		if (["group", "groupEnd"].indexOf(message.log_type) === -1 && message.meta.File.length > 0)
 		{
-			console.log("%c" + message.meta.File + ":" + (message.meta.Line :: '<unknown>'), "color: #aaa;")
+			console.log("%c" + message.meta.File + ":" + (message.meta.Line ? message.meta.Line : '<unknown>'), "color: #aaa;")
 		}
 		if (message.log_type === "table")
 		{

--- a/webug/assets/javascripts/logging.js
+++ b/webug/assets/javascripts/logging.js
@@ -3,9 +3,12 @@ chrome.runtime.onMessage.addListener(function(message, sender)
 	if (message.type === "webug.log")
 	{
 		var args = [];
-		if (["group", "groupEnd"].indexOf(message.log_type) === -1)
+		if (
+			["group", "groupEnd"].indexOf(message.log_type) === -1 && 
+			message.meta.File.length > 0
+		)
 		{
-			console.log("%c" + message.meta.File + ":" + message.meta.Line, "color: #aaa;")
+			console.log("%c" + message.meta.File + ":" + (message.meta.Line :: '<unknown>'), "color: #aaa;")
 		}
 		if (message.log_type === "table")
 		{


### PR DESCRIPTION
I'd the issue of empty lines - or at least just a ":", because PHPUnit sometimes didnt detect y file and line information.
Therefore I've changed the logging.js a bit to prevent that.

Cheers!