### PR TITLE
Fixed repeated log messages in console 

### DIFF
--- a/webug/assets/javascripts/webug.js
+++ b/webug/assets/javascripts/webug.js
@@ -43,22 +43,20 @@ function processWfHeaders(headers)
 
 function logToTab(tabId, meta, type, message, label)
 {
-	var timer, retries = 0;
+	var retries = 3;
 
 	function send()
 	{
 		chrome.tabs.sendMessage(tabId, { type: "webug.log", meta: meta, log_type: type, message: message, label: label }, function(resp)
 		{
-			if (resp || retries >= 3)
+			if (!resp && chrome.runtime.lastError && retries-- > 0)
 			{
-				clearInterval(timer);
+				return send();
 			}
-			retries++;
 		});
 	}
 
 	send();
-	timer = setInterval(send, 100);
 }
 
 chrome.browserAction.onClicked.addListener(function(tab)


### PR DESCRIPTION
Commit 1d779818ce9f1f3ecd809c0b92d419d6d3ba28d8 added 'retry if failed' procedure for logToTab function if the responseCallback hasn't been invoked within a 100ms timeout - which doesn't seem reliable and often causes false-positives and thus repeated log messages in console.

Proposed fix implements fail detection/retry according to the [docs](https://developer.chrome.com/extensions/tabs#method-sendMessage) which states that if a sendMessage request fails, a callback will be invoked with no arguments and runtime.lastError will be set. 
